### PR TITLE
APIキーの作成と有効化

### DIFF
--- a/lib/ohakuma-api-stack.ts
+++ b/lib/ohakuma-api-stack.ts
@@ -1,5 +1,5 @@
 import * as cdk from '@aws-cdk/core';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import { LambdaRestApi, ApiKeySourceType } from '@aws-cdk/aws-apigateway';
 import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
 import * as dynamodb from '@aws-cdk/aws-dynamodb';
 import { ResourceName } from './resourceName';
@@ -34,10 +34,16 @@ export class OhakumaApiStack extends cdk.Stack {
     bearTable.grantReadWriteData(manageBearLambda);
 
     // API Gateway
-    const apiName = resourceName.apiName('manage-bear');
-    new apigw.LambdaRestApi(this, apiName, {
-      restApiName: apiName,
+    const manageBearApiName = resourceName.apiName('manage-bear');
+    const manageBearApi = new LambdaRestApi(this, manageBearApiName, {
+      restApiName: manageBearApiName,
       handler: manageBearLambda,
+    });
+
+    // API Key
+    const manageBearApiKeyName = resourceName.apiKeyName('manage-bear');
+    const manageBearApiKey = manageBearApi.addApiKey(manageBearApiKeyName, {
+      apiKeyName: manageBearApiKeyName,
     });
   }
 }

--- a/lib/ohakuma-api-stack.ts
+++ b/lib/ohakuma-api-stack.ts
@@ -44,6 +44,9 @@ export class OhakumaApiStack extends cdk.Stack {
       handler: manageBearLambda,
       apiKeySourceType: ApiKeySourceType.HEADER,
       proxy: false,
+      deployOptions: {
+        stageName: 'v1',
+      },
     });
     manageBearApi.root.addMethod(
       'ANY',

--- a/lib/ohakuma-api-stack.ts
+++ b/lib/ohakuma-api-stack.ts
@@ -45,22 +45,21 @@ export class OhakumaApiStack extends cdk.Stack {
       apiKeySourceType: ApiKeySourceType.HEADER,
       proxy: false,
     });
-
     manageBearApi.root.addMethod(
       'ANY',
       new LambdaIntegration(manageBearLambda),
       { apiKeyRequired: true }
     );
 
-    // API Key
-    const manageBearApiKeyName = resourceName.apiKeyName('manage-bear');
-    const manageBearApiKey = manageBearApi.addApiKey(manageBearApiKeyName, {
-      apiKeyName: manageBearApiKeyName,
-    });
-
-    //TODO 名前を直す
-    const usagePlan = manageBearApi.addUsagePlan('hoge', { name: 'fuga' });
-    usagePlan.addApiKey(manageBearApiKey);
-    usagePlan.addApiStage({ stage: manageBearApi.deploymentStage });
+    // APIキーの発行とAPI Gatewayへの紐付け
+    const createApiKey = (apigw: LambdaRestApi, keyUserName: string) => {
+      const apiKeyName = resourceName.apiKeyName(keyUserName);
+      const apiKey = apigw.addApiKey(apiKeyName, { apiKeyName: apiKeyName });
+      const usagePlan = apigw.addUsagePlan(keyUserName, { name: keyUserName });
+      usagePlan.addApiKey(apiKey);
+      usagePlan.addApiStage({ stage: apigw.deploymentStage });
+    };
+    createApiKey(manageBearApi, 'bot');
+    createApiKey(manageBearApi, 'member');
   }
 }

--- a/lib/resourceName.ts
+++ b/lib/resourceName.ts
@@ -15,6 +15,10 @@ export class ResourceName {
     return this.basicName(`${name}-api`);
   }
 
+  public apiKeyName(name: string): string {
+    return this.basicName(`${name}-apikey`);
+  }
+
   public lambdaName(name: string): string {
     return this.basicName(`${name}-function`);
   }

--- a/test/ohakuma-api.test.ts
+++ b/test/ohakuma-api.test.ts
@@ -19,6 +19,17 @@ test('Lambda', () => {
 
 test('API Gateway', () => {
   expectCDK(stack).to(countResources('AWS::ApiGateway::RestApi', 1));
+  expectCDK(stack).to(countResources('AWS::ApiGateway::ApiKey', 2));
+  expectCDK(stack).to(
+    haveResource('AWS::ApiGateway::ApiKey', {
+      Name: resourceName.apiKeyName('bot'),
+    })
+  );
+  expectCDK(stack).to(
+    haveResource('AWS::ApiGateway::ApiKey', {
+      Name: resourceName.apiKeyName('member'),
+    })
+  );
 });
 
 test('DynamoDB', () => {


### PR DESCRIPTION
APIの認証をAPIキーで行う実装を行った。

これはベストプラクティスに反する (参考1)が、
ユーザーが少ない現状では、
デメリットであるAPIキーの上限、セキュリティ面に比べて、メリットである実装の容易さが勝ると判断した。

### 対応
- APIキーを作成
  - botとメンバー用の2本
- API呼び出し時にAPIキーが必須になるよう設定
  - スロットリングの設定は行っていない

### 参考
1. [Amazon API Gateway で API キーを使わずに認証とアクセス制御を行う](https://aws.amazon.com/jp/blogs/news/amazon-api-gateway-cognito-waf/)