### PR TITLE
API Gatewayの設定の不具合の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 *.js
 !jest.config.js
 *.d.ts

--- a/lib/ohakuma-api-stack.ts
+++ b/lib/ohakuma-api-stack.ts
@@ -1,12 +1,9 @@
 import * as cdk from '@aws-cdk/core';
-import {
-  LambdaRestApi,
-  ApiKeySourceType,
-  LambdaIntegration,
-} from '@aws-cdk/aws-apigateway';
+import * as apigw from '@aws-cdk/aws-apigateway';
 import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
 import * as dynamodb from '@aws-cdk/aws-dynamodb';
 import { ResourceName } from './resourceName';
+import * as logs from '@aws-cdk/aws-logs';
 
 export class OhakumaApiStack extends cdk.Stack {
   constructor(
@@ -37,30 +34,48 @@ export class OhakumaApiStack extends cdk.Stack {
 
     bearTable.grantReadWriteData(manageBearLambda);
 
+    const restApiLogAccessLogGroup = new logs.LogGroup(
+      this,
+      'RestApiLogAccessLogGroup',
+      {
+        logGroupName: `/aws/apigateway/rest-api-access-log`,
+        retention: 365,
+      }
+    );
     // API Gateway
     const manageBearApiName = resourceName.apiName('manage-bear');
-    const manageBearApi = new LambdaRestApi(this, manageBearApiName, {
+    const manageBearApi = new apigw.LambdaRestApi(this, manageBearApiName, {
       restApiName: manageBearApiName,
       handler: manageBearLambda,
-      apiKeySourceType: ApiKeySourceType.HEADER,
+      apiKeySourceType: apigw.ApiKeySourceType.HEADER,
       proxy: false,
       deployOptions: {
         stageName: 'v1',
+        loggingLevel: apigw.MethodLoggingLevel.INFO,
+        //アクセスログの設定
+        accessLogDestination: new apigw.LogGroupLogDestination(
+          restApiLogAccessLogGroup
+        ),
+        accessLogFormat: apigw.AccessLogFormat.clf(),
       },
     });
     manageBearApi.root.addMethod(
       'ANY',
-      new LambdaIntegration(manageBearLambda),
+      new apigw.LambdaIntegration(manageBearLambda),
       { apiKeyRequired: true }
     );
+    const anyProxy = manageBearApi.root.addResource('{proxy+}');
+    anyProxy.addMethod(`ANY`, new apigw.LambdaIntegration(manageBearLambda), {
+      apiKeyRequired: true,
+    });
 
     // APIキーの発行とAPI Gatewayへの紐付け
-    const createApiKey = (apigw: LambdaRestApi, keyUserName: string) => {
+    const createApiKey = (api: apigw.LambdaRestApi, keyUserName: string) => {
       const apiKeyName = resourceName.apiKeyName(keyUserName);
-      const apiKey = apigw.addApiKey(apiKeyName, { apiKeyName: apiKeyName });
-      const usagePlan = apigw.addUsagePlan(keyUserName, { name: keyUserName });
+      const apiKey = api.addApiKey(apiKeyName, { apiKeyName: apiKeyName });
+      const usagePlan = api.addUsagePlan(keyUserName, { name: keyUserName });
       usagePlan.addApiKey(apiKey);
-      usagePlan.addApiStage({ stage: apigw.deploymentStage });
+      usagePlan.addApiStage({ stage: api.deploymentStage });
     };
     createApiKey(manageBearApi, 'bot');
     createApiKey(manageBearApi, 'member');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "cdk": "cdk",
     "deploy": "cdk deploy  --require-approval never",
-    "dev": "IS_LOCAL=true ts-node src/lambda/handlers/api-gw/index.ts"
+    "dev": "IS_LOCAL=true ts-node src/api/handlers/api-gw/index.ts"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.118.0",

--- a/src/lambda/handlers/api-gw/app.ts
+++ b/src/lambda/handlers/api-gw/app.ts
@@ -18,7 +18,7 @@ app.delete('/bears/:id', bm.deleteBear);
 
 // error handler
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {
-  console.error(err);
+  console.log(err);
   res.status(500).json('Internal Server Error');
 });
 


### PR DESCRIPTION
（別ブランチで作業中のものを急遽修正）
API Gatewayの`/`以外のパスが500エラーを返していた。

問題だったプロキシの設定を修正。
デバッグのため、ログの設定等も行った。
